### PR TITLE
Secd 561/make id ip and lastscanned required to produce

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ need to be queried from the Nexpose API, so that you can find out which
 
 ### Environment Variables
 Here are the environment variables that need to be set
-|Name              |Required | Description                                                    |Example                        |
+
+|Name             |Required | Description                                                    |Example                        |
 |-----------------|:-------:|----------------------------------------------------------------|-------------------------------|
 |NEXPOSE_HOST     |Yes      |Scheme and host for the Nexpose instance                        | https://nexpose.mycompany.com |
 |NEXPOSE_USERNAME |Yes      |Username to access the Nexpose instance                         | myusername                    |

--- a/pkg/assetfetcher/asset.go
+++ b/pkg/assetfetcher/asset.go
@@ -316,6 +316,9 @@ func (a Asset) AssetPayloadToAssetEvent() (domain.AssetEvent, error) {
 	if err != nil {
 		return domain.AssetEvent{}, err
 	}
+	if a.ID == 0 || a.IP == "" || lastScanned.IsZero() {
+		return domain.AssetEvent{}, &MissingRequiredFields{a.ID, a.IP, lastScanned}
+	}
 	return domain.AssetEvent{
 		ID:          a.ID,
 		Hostname:    a.HostName,

--- a/pkg/assetfetcher/asset_test.go
+++ b/pkg/assetfetcher/asset_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/asecurityteam/nexpose-asset-producer/pkg/domain"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -55,4 +56,60 @@ func TestLastAssessedForVulnerabilities(t *testing.T) {
 		})
 	}
 
+}
+
+func TestAssetPayloadToAssetEventSuccess(t *testing.T) {
+	date := time.Date(2019, time.April, 22, 15, 2, 44, 0, time.UTC)
+	asset := Asset{
+		ID:      1,
+		IP:      "127.0.0.1",
+		History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: "2019-04-22T15:02:44.000Z"}},
+	}
+	expectedAssetEvent := domain.AssetEvent{
+		ID:          1,
+		IP:          "127.0.0.1",
+		LastScanned: date,
+	}
+
+	assetEvent, err := asset.AssetPayloadToAssetEvent()
+	assert.NoError(t, err)
+	assert.Equal(t, expectedAssetEvent, assetEvent)
+}
+
+func TestAssetPayloadToAssetEventError(t *testing.T) {
+	tests := []struct {
+		name  string
+		asset Asset
+	}{
+		{
+			"No ID",
+			Asset{
+				IP:      "127.0.0.1",
+				History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: "2019-04-22T15:02:44.000Z"}},
+			},
+		},
+		{
+			"No IP",
+			Asset{
+				ID:      1,
+				History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: "2019-04-22T15:02:44.000Z"}},
+			},
+		},
+		{
+			"No LastScanned",
+			Asset{
+				ID: 1,
+				IP: "127.0.0.1",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			_, err := test.asset.AssetPayloadToAssetEvent()
+			lastScanned, _ := test.asset.History.lastScannedTimestamp()
+			assert.Equal(t, &MissingRequiredFields{test.asset.ID, test.asset.IP, lastScanned}, err)
+
+		})
+	}
 }

--- a/pkg/assetfetcher/errors.go
+++ b/pkg/assetfetcher/errors.go
@@ -1,6 +1,9 @@
 package assetfetcher
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 // URLParsingError when trying to parse the given host or URL
 type URLParsingError struct {
@@ -66,4 +69,16 @@ type ErrorConvertingAssetPayload struct {
 // Error returns an ErrorConvertingAssetPayload
 func (e *ErrorConvertingAssetPayload) Error() string {
 	return fmt.Sprintf("Error converting asset %v payload to event %v", e.AssetID, e.Inner)
+}
+
+// MissingRequiredFields represents an error we get if the ID, IP, or lastScanned date is empty
+type MissingRequiredFields struct {
+	AssetID          int64
+	AssetIP          string
+	AssetLastScanned time.Time
+}
+
+// Error returns an MissingRequiredFields
+func (e *MissingRequiredFields) Error() string {
+	return fmt.Sprintf("Required fields are missing. ID: %v, IP: %s, LastScanned: %v", e.AssetID, e.AssetIP, e.AssetLastScanned)
 }

--- a/pkg/assetfetcher/errors_test.go
+++ b/pkg/assetfetcher/errors_test.go
@@ -3,6 +3,7 @@ package assetfetcher
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -18,6 +19,7 @@ type errorTest struct {
 func TestAssetFetcherErrors(t *testing.T) {
 	nexposeTestURL := "http://nexpose-instance.com"
 	customError := errors.New("myCustomError")
+	lastScannedNow := time.Now()
 	tc := []errorTest{
 		{
 			"URLParsingError",
@@ -48,6 +50,11 @@ func TestAssetFetcherErrors(t *testing.T) {
 			"ErrorConvertingAssetPayload",
 			&ErrorConvertingAssetPayload{123456, customError},
 			fmt.Sprintf("Error converting asset 123456 payload to event %v", customError),
+		},
+		{
+			"MissingRequiredFields",
+			&MissingRequiredFields{123456, "", lastScannedNow},
+			fmt.Sprintf("Required fields are missing. ID: 123456, IP: , LastScanned: %v", lastScannedNow),
 		},
 	}
 
@@ -90,6 +97,10 @@ func TestAssetFetcherErrorsCanBeNil(t *testing.T) {
 		{
 			"ErrorConvertingAssetPayload",
 			&ErrorConvertingAssetPayload{},
+		},
+		{
+			"MissingRequiredFields",
+			&MissingRequiredFields{},
 		},
 	}
 

--- a/pkg/assetfetcher/http_test.go
+++ b/pkg/assetfetcher/http_test.go
@@ -20,13 +20,15 @@ func TestFetchAssetsSuccess(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockRT := NewMockRoundTripper(ctrl)
-
-	expectedAsset := domain.AssetEvent{
-		IP: "127.0.0.1",
-		ID: 123456,
+	asset := Asset{
+		IP:      "127.0.0.1",
+		ID:      123456,
+		History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: "2019-05-14T15:03:47.000Z"}},
 	}
+	expectedAsset, err := asset.AssetPayloadToAssetEvent()
+	assert.NoError(t, err)
 	resp := SiteAssetsResponse{
-		Resources: []Asset{{IP: "127.0.0.1", ID: 123456}},
+		Resources: []Asset{asset},
 		Page: Page{
 			TotalPages:     1,
 			TotalResources: 1,
@@ -75,25 +77,28 @@ func TestFetchAssetsSuccessWithOneMakeRequestCall(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockRT := NewMockRoundTripper(ctrl)
-
-	expectedAsset1 := domain.AssetEvent{
-		IP: "127.0.0.1",
-		ID: 123,
+	asset1 := Asset{
+		IP:      "127.0.0.1",
+		ID:      123456,
+		History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: "2019-05-14T15:03:47.000Z"}},
 	}
-	expectedAsset2 := domain.AssetEvent{
-		IP: "127.0.0.2",
-		ID: 456,
+	expectedAsset1, _ := asset1.AssetPayloadToAssetEvent()
+	asset2 := Asset{
+		IP:      "127.0.0.1",
+		ID:      123456,
+		History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: "2019-05-14T15:03:47.000Z"}},
 	}
+	expectedAsset2, _ := asset2.AssetPayloadToAssetEvent()
 	page := Page{
 		TotalPages:     2,
 		TotalResources: 2,
 	}
 	resp1 := SiteAssetsResponse{
-		Resources: []Asset{{IP: "127.0.0.1", ID: 123}},
+		Resources: []Asset{asset1},
 		Page:      page,
 	}
 	resp2 := SiteAssetsResponse{
-		Resources: []Asset{{IP: "127.0.0.2", ID: 456}},
+		Resources: []Asset{asset2},
 		Page:      page,
 	}
 	respJSON1, _ := json.Marshal(resp1)
@@ -145,26 +150,30 @@ func TestFetchAssetsSuccessWithMultipleMakeRequestsCalled(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockRT := NewMockRoundTripper(ctrl)
-
-	expectedAsset1 := domain.AssetEvent{ID: 1}
-	expectedAsset2 := domain.AssetEvent{ID: 2}
-	expectedAsset3 := domain.AssetEvent{ID: 3}
-	expectedAsset4 := domain.AssetEvent{ID: 4}
-	expectedAsset5 := domain.AssetEvent{ID: 5}
+	asset1 := Asset{IP: "127.0.0.1", ID: 1, History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: "2019-05-14T15:03:47.000Z"}}}
+	expectedAsset1, _ := asset1.AssetPayloadToAssetEvent()
+	asset2 := Asset{IP: "127.0.0.2", ID: 2, History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: "2019-05-14T15:03:47.000Z"}}}
+	expectedAsset2, _ := asset1.AssetPayloadToAssetEvent()
+	asset3 := Asset{IP: "127.0.0.3", ID: 3, History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: "2019-05-14T15:03:47.000Z"}}}
+	expectedAsset3, _ := asset1.AssetPayloadToAssetEvent()
+	asset4 := Asset{IP: "127.0.0.4", ID: 4, History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: "2019-05-14T15:03:47.000Z"}}}
+	expectedAsset4, _ := asset1.AssetPayloadToAssetEvent()
+	asset5 := Asset{IP: "127.0.0.5", ID: 5, History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: "2019-05-14T15:03:47.000Z"}}}
+	expectedAsset5, _ := asset1.AssetPayloadToAssetEvent()
 	page := Page{
 		TotalPages:     3,
 		TotalResources: 5,
 	}
 	page1Resp := SiteAssetsResponse{
-		Resources: []Asset{{ID: 1}, {ID: 2}},
+		Resources: []Asset{asset1, asset2},
 		Page:      page,
 	}
 	page2Resp := SiteAssetsResponse{
-		Resources: []Asset{{ID: 3}, {ID: 4}},
+		Resources: []Asset{asset3, asset4},
 		Page:      page,
 	}
 	page3Resp := SiteAssetsResponse{
-		Resources: []Asset{{ID: 5}},
+		Resources: []Asset{asset5},
 		Page:      page,
 	}
 	respJSON1, _ := json.Marshal(page1Resp)
@@ -227,19 +236,22 @@ func TestFetchAssetsSuccessWithMultipleMakeRequestsCalledWithError(t *testing.T)
 	defer ctrl.Finish()
 	mockRT := NewMockRoundTripper(ctrl)
 
-	expectedAsset1 := domain.AssetEvent{ID: 1}
-	expectedAsset2 := domain.AssetEvent{ID: 2}
-	expectedAsset3 := domain.AssetEvent{ID: 3}
+	asset1 := Asset{IP: "127.0.0.1", ID: 1, History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: "2019-05-14T15:03:47.000Z"}}}
+	expectedAsset1, _ := asset1.AssetPayloadToAssetEvent()
+	asset2 := Asset{IP: "127.0.0.2", ID: 2, History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: "2019-05-14T15:03:47.000Z"}}}
+	expectedAsset2, _ := asset1.AssetPayloadToAssetEvent()
+	asset3 := Asset{IP: "127.0.0.3", ID: 3, History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: "2019-05-14T15:03:47.000Z"}}}
+	expectedAsset3, _ := asset1.AssetPayloadToAssetEvent()
 	page := Page{
 		TotalPages:     3,
 		TotalResources: 5,
 	}
 	page1Resp := SiteAssetsResponse{
-		Resources: []Asset{{ID: 1}, {ID: 2}},
+		Resources: []Asset{asset1, asset2},
 		Page:      page,
 	}
 	page3Resp := SiteAssetsResponse{
-		Resources: []Asset{{ID: 3}},
+		Resources: []Asset{asset3},
 		Page:      page,
 	}
 	respJSON1, _ := json.Marshal(page1Resp)
@@ -497,9 +509,9 @@ func TestMakeRequestSuccess(t *testing.T) {
 	mockRT := NewMockRoundTripper(ctrl)
 
 	asset := Asset{
-		IP: "127.0.0.1",
-		ID: 123456,
-	}
+		IP:      "127.0.0.1",
+		ID:      1,
+		History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: "2019-05-14T15:03:47.000Z"}}}
 	resp := SiteAssetsResponse{
 		Resources: []Asset{asset},
 		Page:      Page{},

--- a/pkg/producer/http.go
+++ b/pkg/producer/http.go
@@ -17,10 +17,10 @@ type AssetProducer struct {
 }
 
 type assetEventPayload struct {
-	LastScanned time.Time `json:"lastScanned,omitempty"`
+	LastScanned time.Time `json:"lastScanned"`
 	Hostname    string    `json:"hostName,omitempty"`
-	ID          int64     `json:"id,omitempty"`
-	IP          string    `json:"ip,omitempty"`
+	ID          int64     `json:"id"`
+	IP          string    `json:"ip"`
 }
 
 // Produce publishes sends the asset event to the streaming appliance

--- a/pkg/producer/http.go
+++ b/pkg/producer/http.go
@@ -17,10 +17,10 @@ type AssetProducer struct {
 }
 
 type assetEventPayload struct {
-	LastScanned time.Time `json:"lastScanned"`
+	LastScanned time.Time `json:"lastScanned,omitempty"`
 	Hostname    string    `json:"hostName,omitempty"`
-	ID          int64     `json:"id"`
-	IP          string    `json:"ip"`
+	ID          int64     `json:"id,omitempty"`
+	IP          string    `json:"ip,omitempty"`
 }
 
 // Produce publishes sends the asset event to the streaming appliance


### PR DESCRIPTION
I'm removing the "omitempty" from the ID, IP, and LastScanned fields in the asset produce payload because assets not useful to downstream services if those fields are not present.