### PR TITLE
Don't produce empty assets.

### DIFF
--- a/pkg/handlers/v1/nexposeassetproducer.go
+++ b/pkg/handlers/v1/nexposeassetproducer.go
@@ -38,6 +38,9 @@ func (h *NexposeScannedAssetProducer) Handle(ctx context.Context, in ScanInfo) {
 			if !ok {
 				assetChan = nil
 			} else {
+				if asset == (domain.AssetEvent{}) {
+					break
+				}
 				stater.Count("assetreceived.success", 1)
 				wg.Add(1)
 				go func(ctx context.Context, asset domain.AssetEvent) {


### PR DESCRIPTION
This change adds a check to see if the asset that's received in the
assetChannel is empty. Although we don't expect to have empty assets,
this can occur if Nexpose returns an empty asset or an asset that is
missing the ID, IP, or the last time it was scanned.