### PR TITLE
Add more descriptive comment to assetFetcher and fixed test comment

### DIFF
--- a/pkg/assetfetcher/http.go
+++ b/pkg/assetfetcher/http.go
@@ -59,8 +59,10 @@ type NexposeAssetFetcher struct {
 	PageSize int
 }
 
-// FetchAssets gets all the assets for a given site ID from Nexpose, with pagination.
-// It returns a channel of assets and a channel of errors that can by asynchronously listened to.
+// FetchAssets gets all the assets for a given site ID from Nexpose. This function is asynchronous, which means
+// you can start listening to the AssetEvent and error channels immediately. Assets will be added to the AssetEvent
+// channel as they're returned from Nexpose and errors will be added to the error channel if there's an error fetching
+// or reading the asset. It's the responsibility of the caller to check if a channel is closed before reading from it.
 func (c *NexposeAssetFetcher) FetchAssets(ctx context.Context, siteID string) (<-chan domain.AssetEvent, <-chan error) {
 	errChan := make(chan error, 1)
 	defer close(errChan)

--- a/pkg/assetfetcher/http_test.go
+++ b/pkg/assetfetcher/http_test.go
@@ -407,7 +407,8 @@ func TestFetchAssetsSuccessWithNoAssetReturned(t *testing.T) {
 
 	assetChan, errChan := nexposeAssetFetcher.FetchAssets(context.Background(), "site67")
 
-	assert.Equal(t, domain.AssetEvent{}, <-assetChan) // An empty asset will be added to assetChan if there's a response with no asset
+	// An empty Asset will be returned on the channel because we're reading from a close channel here - this is expected
+	assert.Equal(t, domain.AssetEvent{}, <-assetChan)
 	assert.Nil(t, <-errChan)
 }
 
@@ -674,7 +675,8 @@ func TestMakeRequestWithNoAssetsReturned(t *testing.T) {
 	close(assetChan)
 	close(errChan)
 
-	assert.Equal(t, domain.AssetEvent{}, <-assetChan) // An empty asset will be added to assetChan if there's a response with no asset
+	// An empty Asset will be returned on the channel because we're reading from a close channel here - this is expected
+	assert.Equal(t, domain.AssetEvent{}, <-assetChan)
 	assert.Nil(t, <-errChan)
 }
 

--- a/pkg/assetfetcher/http_test.go
+++ b/pkg/assetfetcher/http_test.go
@@ -407,7 +407,7 @@ func TestFetchAssetsSuccessWithNoAssetReturned(t *testing.T) {
 
 	assetChan, errChan := nexposeAssetFetcher.FetchAssets(context.Background(), "site67")
 
-	// An empty Asset will be returned on the channel because we're reading from a close channel here - this is expected
+	// An empty Asset will be returned on the channel because we're reading from a closed channel here - this is expected
 	assert.Equal(t, domain.AssetEvent{}, <-assetChan)
 	assert.Nil(t, <-errChan)
 }
@@ -675,7 +675,7 @@ func TestMakeRequestWithNoAssetsReturned(t *testing.T) {
 	close(assetChan)
 	close(errChan)
 
-	// An empty Asset will be returned on the channel because we're reading from a close channel here - this is expected
+	// An empty Asset will be returned on the channel because we're reading from a closed channel here - this is expected
 	assert.Equal(t, domain.AssetEvent{}, <-assetChan)
 	assert.Nil(t, <-errChan)
 }


### PR DESCRIPTION
I was recently working on an issue to make sure we didn't produce empty assets, but in the middle of it, I realized that there's no way that could happen with the way the code is written. Part of what confused me was a test I has that was checking for empty assets on the channel when Nexpose didn't return an asset in its response. The reason there was an empty asset on the channel was not because we were adding an empty asset to the channel, but because reading from a closed channel results in the default value (or nil value) of that channel, which in this case, was an Asset. I added a comment in the test to clear this up and also added a note in the `FetchAssets` comment about checking for closed channels.