### PR TITLE
Remove SiteAssetResponse.Links since it's not used

### DIFF
--- a/pkg/assetfetcher/http.go
+++ b/pkg/assetfetcher/http.go
@@ -25,8 +25,6 @@ const (
 
 // SiteAssetsResponse is the structure of the Nexpose site assets response
 type SiteAssetsResponse struct {
-	// Hypermedia links to corresponding or related resources
-	Links []Link
 	// The details of pagination indicating which page was returned, and how the remaining pages can be retrieved.
 	Page Page
 	// The page of resources returned (resources = assets)

--- a/pkg/assetfetcher/http.go
+++ b/pkg/assetfetcher/http.go
@@ -26,7 +26,7 @@ const (
 // SiteAssetsResponse is the structure of the Nexpose site assets response
 type SiteAssetsResponse struct {
 	// Hypermedia links to corresponding or related resources
-	Links Link
+	Links []Link
 	// The details of pagination indicating which page was returned, and how the remaining pages can be retrieved.
 	Page Page
 	// The page of resources returned (resources = assets)

--- a/pkg/assetfetcher/http_test.go
+++ b/pkg/assetfetcher/http_test.go
@@ -390,7 +390,7 @@ func TestFetchAssetsSuccessWithNoAssetReturned(t *testing.T) {
 			TotalPages:     1,
 			TotalResources: 1,
 		},
-		Links: Link{},
+		Links: []Link{},
 	}
 	respJSON, _ := json.Marshal(resp)
 
@@ -463,7 +463,7 @@ func TestFetchAssetsAssetPayloadToAssetEventError(t *testing.T) {
 			TotalPages:     1,
 			TotalResources: 1,
 		},
-		Links: Link{},
+		Links: []Link{},
 	}
 	respJSON, _ := json.Marshal(resp)
 	mockRT.EXPECT().RoundTrip(gomock.Any()).Return(&http.Response{
@@ -516,7 +516,7 @@ func TestMakeRequestSuccess(t *testing.T) {
 	resp := SiteAssetsResponse{
 		Resources: []Asset{asset},
 		Page:      Page{},
-		Links:     Link{},
+		Links:     []Link{},
 	}
 
 	respJSON, _ := json.Marshal(resp)
@@ -613,7 +613,7 @@ func TestMakeRequestWithAssetPayloadToAssetEventError(t *testing.T) {
 	resp := SiteAssetsResponse{
 		Resources: []Asset{{History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: "not a time"}}}},
 		Page:      Page{},
-		Links:     Link{},
+		Links:     []Link{},
 	}
 	respJSON, _ := json.Marshal(resp)
 	mockRT.EXPECT().RoundTrip(gomock.Any()).Return(&http.Response{
@@ -649,7 +649,7 @@ func TestMakeRequestWithNoAssetsReturned(t *testing.T) {
 	resp := SiteAssetsResponse{
 		Resources: []Asset{},
 		Page:      Page{},
-		Links:     Link{},
+		Links:     []Link{},
 	}
 	respJSON, _ := json.Marshal(resp)
 	mockRT.EXPECT().RoundTrip(gomock.Any()).Return(&http.Response{

--- a/pkg/assetfetcher/http_test.go
+++ b/pkg/assetfetcher/http_test.go
@@ -390,7 +390,6 @@ func TestFetchAssetsSuccessWithNoAssetReturned(t *testing.T) {
 			TotalPages:     1,
 			TotalResources: 1,
 		},
-		Links: []Link{},
 	}
 	respJSON, _ := json.Marshal(resp)
 
@@ -463,7 +462,6 @@ func TestFetchAssetsAssetPayloadToAssetEventError(t *testing.T) {
 			TotalPages:     1,
 			TotalResources: 1,
 		},
-		Links: []Link{},
 	}
 	respJSON, _ := json.Marshal(resp)
 	mockRT.EXPECT().RoundTrip(gomock.Any()).Return(&http.Response{
@@ -516,7 +514,6 @@ func TestMakeRequestSuccess(t *testing.T) {
 	resp := SiteAssetsResponse{
 		Resources: []Asset{asset},
 		Page:      Page{},
-		Links:     []Link{},
 	}
 
 	respJSON, _ := json.Marshal(resp)
@@ -613,7 +610,6 @@ func TestMakeRequestWithAssetPayloadToAssetEventError(t *testing.T) {
 	resp := SiteAssetsResponse{
 		Resources: []Asset{{History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: "not a time"}}}},
 		Page:      Page{},
-		Links:     []Link{},
 	}
 	respJSON, _ := json.Marshal(resp)
 	mockRT.EXPECT().RoundTrip(gomock.Any()).Return(&http.Response{
@@ -649,7 +645,6 @@ func TestMakeRequestWithNoAssetsReturned(t *testing.T) {
 	resp := SiteAssetsResponse{
 		Resources: []Asset{},
 		Page:      Page{},
-		Links:     []Link{},
 	}
 	respJSON, _ := json.Marshal(resp)
 	mockRT.EXPECT().RoundTrip(gomock.Any()).Return(&http.Response{


### PR DESCRIPTION
The Links that Nexpose sends back in its response is not needed, so it
is being removed in this change. All we need from Nexpose here are
are the Assets (Resources) so that we can produce them for the next
consumer and the Page in order to get the total number pages we will
need to paginate through and the total number of assets that will be
returned.