### PR TITLE
SECD-650 Check response status code from Nexpose and http event producer

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -13,10 +13,6 @@
   version = "0.1.0"
 
 [[constraint]]
-  name = "github.com/asecurityteam/serverfull-gateway"
-  branch = "master"
-
-[[constraint]]
   name = "github.com/asecurityteam/runhttp"
   branch = "master"
 
@@ -27,8 +23,3 @@
 [[constraint]]
   name = "github.com/stretchr/testify"
   version = "1.3.0"
-
-[[constraint]]
-  name = "github.com/aws/aws-lambda-go"
-  version = "1.8.1"
-

--- a/pkg/assetfetcher/http.go
+++ b/pkg/assetfetcher/http.go
@@ -130,6 +130,12 @@ func (c *NexposeAssetFetcher) makeRequest(ctx context.Context, wg *sync.WaitGrou
 		errChan <- &ErrorReadingNexposeResponse{err, req.URL.String()}
 		return
 	}
+
+	if res.StatusCode != http.StatusOK {
+		errChan <- &ErrorFetchingAssets{Inner: fmt.Errorf("unexpected response from nexpose: %d %s",
+			res.StatusCode, string(respBody))}
+		return
+	}
 	var siteAssetResp SiteAssetsResponse
 	if err := json.Unmarshal(respBody, &siteAssetResp); err != nil {
 		errChan <- &ErrorParsingJSONResponse{err, req.URL.String()}

--- a/pkg/producer/config.go
+++ b/pkg/producer/config.go
@@ -1,11 +1,14 @@
 package producer
 
-import "context"
+import (
+	"context"
+	"net/url"
+)
 
 // ProducerConfig holds configuration required to send Nexpose assets
 // to a queue via an HTTP Producer
 type ProducerConfig struct {
-	Endpoint string
+	Endpoint string `description:"The scheme and URL of an HTTP producer."`
 }
 
 // Name is used by the settings library and will add a "HTTPPRODUCER"
@@ -21,7 +24,12 @@ type ProducerConfigComponent struct{}
 // Settings can be used to populate default values if there are any
 func (*ProducerConfigComponent) Settings() *ProducerConfig { return &ProducerConfig{} }
 
-// New constructs a NexposeAssetFetcher from a config.
+// New constructs a AssetProducer from a config.
 func (*ProducerConfigComponent) New(_ context.Context, c *ProducerConfig) (*AssetProducer, error) {
-	return &AssetProducer{}, nil
+	endpoint, err := url.Parse(c.Endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AssetProducer{Endpoint: endpoint}, nil
 }

--- a/pkg/producer/config_test.go
+++ b/pkg/producer/config_test.go
@@ -1,12 +1,28 @@
 package producer
 
 import (
+	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestName(t *testing.T) {
-	producerConfig := ProducerConfig{}
-	assert.Equal(t, "HTTPProducer", producerConfig.Name())
+func TestProducerConfig_Name(t *testing.T) {
+	producerComponent := &ProducerConfigComponent{}
+	producerConfig := producerComponent.Settings()
+	require.Equal(t, "HTTPProducer", producerConfig.Name())
+}
+
+func TestProducerComponent_New(t *testing.T) {
+	config := &ProducerConfig{Endpoint: "http://localhost"}
+	producerComponent := &ProducerConfigComponent{}
+	_, e := producerComponent.New(context.Background(), config)
+	require.Nil(t, e)
+}
+
+func TestProducerComponent_New_InvalidEndpoint(t *testing.T) {
+	config := &ProducerConfig{Endpoint: "~!@#$%^&*()_+:?><!@#$%^&*())_:"}
+	producerComponent := &ProducerConfigComponent{}
+	_, e := producerComponent.New(context.Background(), config)
+	require.NotNil(t, e)
 }

--- a/pkg/producer/http_test.go
+++ b/pkg/producer/http_test.go
@@ -5,55 +5,92 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/asecurityteam/nexpose-asset-producer/pkg/domain"
 	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestProduceSuccess(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	mockRT := NewMockRoundTripper(ctrl)
-
-	asset := domain.AssetEvent{
-		IP: "127.0.0.1",
-		ID: 123456,
-	}
-
-	respJSON, _ := json.Marshal(asset)
-	respReader := bytes.NewReader(respJSON)
-	mockRT.EXPECT().RoundTrip(gomock.Any()).Return(&http.Response{
-		Body:       ioutil.NopCloser(respReader),
-		StatusCode: http.StatusOK,
-	}, nil)
-
-	producer := &AssetProducer{
-		HTTPClient: &http.Client{Transport: mockRT},
-		Endpoint:   "http://localhost",
-	}
-	err := producer.Produce(context.Background(), asset)
-	assert.Nil(t, err)
+type errReader struct {
+	Error error
 }
 
-func TestProduceError(t *testing.T) {
+func (r *errReader) Read(_ []byte) (int, error) {
+	return 0, r.Error
+}
+
+func TestProduce(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockRT := NewMockRoundTripper(ctrl)
-
-	mockRT.EXPECT().RoundTrip(gomock.Any()).Return(nil, errors.New("HTTPError"))
 
 	asset := domain.AssetEvent{
 		IP: "127.0.0.1",
 		ID: 123456,
 	}
+	respJSON, _ := json.Marshal(asset)
+	respReader := bytes.NewReader(respJSON)
+	endpoint, _ := url.Parse("http://localhost")
 	producer := &AssetProducer{
 		HTTPClient: &http.Client{Transport: mockRT},
-		Endpoint:   "http://localhost",
+		Endpoint:   endpoint,
 	}
-	err := producer.Produce(context.Background(), asset)
-	assert.NotNil(t, err)
+
+	tests := []struct {
+		name        string
+		response    *http.Response
+		responseErr error
+		expectErr   bool
+	}{
+		{
+			name: "success",
+			response: &http.Response{
+				Body:       ioutil.NopCloser(respReader),
+				StatusCode: http.StatusOK,
+			},
+			responseErr: nil,
+			expectErr:   false,
+		},
+		{
+			name:        "request error",
+			response:    nil,
+			responseErr: errors.New("HTTPError"),
+			expectErr:   true,
+		},
+		{
+			name: "non 200 status code",
+			response: &http.Response{
+				Body:       ioutil.NopCloser(respReader),
+				StatusCode: http.StatusNotFound,
+			},
+			responseErr: nil,
+			expectErr:   true,
+		},
+		{
+			name: "io read error",
+			response: &http.Response{
+				Body:       ioutil.NopCloser(&errReader{Error: fmt.Errorf("io read error")}),
+				StatusCode: http.StatusOK,
+			},
+			responseErr: nil,
+			expectErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockRT.EXPECT().RoundTrip(gomock.Any()).Return(tt.response, tt.responseErr)
+			err := producer.Produce(context.Background(), asset)
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.Nil(t, err)
+		})
+	}
 }


### PR DESCRIPTION
Add a check for non-200 status codes in the response from the Nexpose API
and http producer. Without this check, it's possible for error responses
to be treated as successes.

* Check status code returned by Nexpose API and HTTP producer
* Rework producer tests to table tests, add additional cases
* Update producer endpoint type to use url.URL instead of string
* Fix bug in producer component not setting endpoint