### PR TITLE
Remove camel casing from hostname field in output

### DIFF
--- a/api-outbound.yaml
+++ b/api-outbound.yaml
@@ -242,7 +242,7 @@ components:
           type: string
           format: date-time
           description: The last time the asset was scanned in ISO8601 format.
-        hostName:
+        hostname:
           type: string
           description: The primary host name (local or FQDN) of the asset.
         id:

--- a/pkg/producer/http.go
+++ b/pkg/producer/http.go
@@ -21,7 +21,7 @@ type AssetProducer struct {
 
 type assetEventPayload struct {
 	LastScanned time.Time `json:"lastScanned,omitempty"`
-	Hostname    string    `json:"hostName,omitempty"`
+	Hostname    string    `json:"hostname,omitempty"`
 	ID          int64     `json:"id,omitempty"`
 	IP          string    `json:"ip,omitempty"`
 }


### PR DESCRIPTION
Removing the camel case 'hostName' from the producer output, as downstream services expect the hostname field to be named 'hostname'.