### PR TITLE
refactor to move encapsulation of 'should we continue processing this…

### DIFF
--- a/pkg/assetfetcher/asset_test.go
+++ b/pkg/assetfetcher/asset_test.go
@@ -131,9 +131,12 @@ func TestAssetPayloadToAssetEventErrorNeverBeenScanned(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {
+			// per the AssetPayloadToAssetEvent docs, callers should only call the function
+			// when the Asset can be cleanly mapped.  The two test structs cannot, but this
+			// test remains to ensure the function handles such a case appropriately
 			_, err := test.asset.AssetPayloadToAssetEvent()
-			assert.Equal(t, &AssetNotScanned{test.asset.ID, test.asset.IP}, err)
-
+			var lastScanned time.Time // intentionally empty
+			assert.Equal(t, &MissingRequiredFields{test.asset.ID, test.asset.IP, lastScanned}, err)
 		})
 	}
 }

--- a/pkg/assetfetcher/config.go
+++ b/pkg/assetfetcher/config.go
@@ -3,6 +3,8 @@ package assetfetcher
 import (
 	"context"
 	"net/url"
+
+	"github.com/asecurityteam/runhttp"
 )
 
 // AssetFetcherConfig holds configuration to connect to Nexpose
@@ -39,5 +41,6 @@ func (*AssetFetcherConfigComponent) New(_ context.Context, c *AssetFetcherConfig
 	return &NexposeAssetFetcher{
 		Host:     host,
 		PageSize: c.PageSize,
+		StatFn:   runhttp.StatFromContext,
 	}, nil
 }

--- a/pkg/assetfetcher/errors.go
+++ b/pkg/assetfetcher/errors.go
@@ -82,14 +82,3 @@ type MissingRequiredFields struct {
 func (e *MissingRequiredFields) Error() string {
 	return fmt.Sprintf("required fields are missing. ID: %v, IP: %s, LastScanned: %v", e.AssetID, e.AssetIP, e.AssetLastScanned)
 }
-
-// AssetNotScanned represents an error when the asset being checked has never been scanned
-type AssetNotScanned struct {
-	AssetID int64
-	AssetIP string
-}
-
-// Error prints a useful message indicating why an asset scan report will not be produced
-func (e *AssetNotScanned) Error() string {
-	return fmt.Sprintf("this Nexpose asset has never been scanned, so no scan report can be produced. ID: %v, IP: %s", e.AssetID, e.AssetIP)
-}

--- a/pkg/assetfetcher/errors_test.go
+++ b/pkg/assetfetcher/errors_test.go
@@ -56,11 +56,6 @@ func TestAssetFetcherErrors(t *testing.T) {
 			&MissingRequiredFields{123456, "", lastScannedNow},
 			fmt.Sprintf("required fields are missing. ID: 123456, IP: , LastScanned: %v", lastScannedNow),
 		},
-		{
-			"AssetNotScanned",
-			&AssetNotScanned{123456, "abc"},
-			fmt.Sprintf("this Nexpose asset has never been scanned, so no scan report can be produced. ID: %v, IP: %s", 123456, "abc"),
-		},
 	}
 
 	for _, tt := range tc {

--- a/pkg/assetfetcher/http.go
+++ b/pkg/assetfetcher/http.go
@@ -51,7 +51,8 @@ type NexposeAssetFetcher struct {
 	Host *url.URL
 	// The number of assets that should be returned at one time
 	PageSize int
-	StatFn   domain.StatFn
+	// Stat Function to report custom statistics
+	StatFn domain.StatFn
 }
 
 // FetchAssets gets all the assets for a given site ID from Nexpose. This function is asynchronous, which means

--- a/pkg/assetfetcher/http_test.go
+++ b/pkg/assetfetcher/http_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/asecurityteam/nexpose-asset-producer/pkg/domain"
+	"github.com/asecurityteam/runhttp"
 	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -46,6 +47,7 @@ func TestFetchAssetsSuccess(t *testing.T) {
 		HTTPClient: &http.Client{Transport: mockRT},
 		Host:       host,
 		PageSize:   100,
+		StatFn:     runhttp.StatFromContext,
 	}
 
 	assetChan, errChan := nexposeAssetFetcher.FetchAssets(context.Background(), "site67")
@@ -103,6 +105,7 @@ func TestFetchAssetsSuccessNoScans(t *testing.T) {
 		HTTPClient: &http.Client{Transport: mockRT},
 		Host:       host,
 		PageSize:   100,
+		StatFn:     runhttp.StatFromContext,
 	}
 
 	assetChan, errChan := nexposeAssetFetcher.FetchAssets(context.Background(), "site67")
@@ -173,6 +176,7 @@ func TestFetchAssetsSuccessWithOneMakeRequestCall(t *testing.T) {
 		HTTPClient: &http.Client{Transport: mockRT},
 		Host:       host,
 		PageSize:   1,
+		StatFn:     runhttp.StatFromContext,
 	}
 
 	assetChan, errChan := nexposeAssetFetcher.FetchAssets(context.Background(), "site67")
@@ -253,6 +257,7 @@ func TestFetchAssetsSuccessWithMultipleMakeRequestsCalled(t *testing.T) {
 		HTTPClient: &http.Client{Transport: mockRT},
 		Host:       host,
 		PageSize:   2, // with a page size of 2: 2 assets will be returned for pages 1 and 2, and 1 will be returned on page 3
+		StatFn:     runhttp.StatFromContext,
 	}
 
 	assetChan, errChan := nexposeAssetFetcher.FetchAssets(context.Background(), "site67")
@@ -329,6 +334,7 @@ func TestFetchAssetsSuccessWithMultipleMakeRequestsCalledWithError(t *testing.T)
 		HTTPClient: &http.Client{Transport: mockRT},
 		Host:       host,
 		PageSize:   2,
+		StatFn:     runhttp.StatFromContext,
 	}
 
 	assetChan, errChan := nexposeAssetFetcher.FetchAssets(context.Background(), "site67")
@@ -376,6 +382,7 @@ func TestFetchAssetsBadJSONInResponseError(t *testing.T) {
 	nexposeAssetFetcher := &NexposeAssetFetcher{
 		HTTPClient: &http.Client{Transport: mockRT},
 		Host:       host,
+		StatFn:     runhttp.StatFromContext,
 	}
 
 	_, errChan := nexposeAssetFetcher.FetchAssets(context.Background(), "site67")
@@ -406,6 +413,7 @@ func TestFetchAssetsWithErrorReadingResponse(t *testing.T) {
 		HTTPClient: &http.Client{Transport: mockRT},
 		Host:       host,
 		PageSize:   100,
+		StatFn:     runhttp.StatFromContext,
 	}
 
 	assetChan, errChan := nexposeAssetFetcher.FetchAssets(context.Background(), "site67")
@@ -457,6 +465,7 @@ func TestFetchAssetsSuccessWithNoAssetReturned(t *testing.T) {
 	nexposeAssetFetcher := &NexposeAssetFetcher{
 		HTTPClient: &http.Client{Transport: mockRT},
 		Host:       host,
+		StatFn:     runhttp.StatFromContext,
 	}
 
 	assetChan, errChan := nexposeAssetFetcher.FetchAssets(context.Background(), "site67")
@@ -478,6 +487,7 @@ func TestFetchAssetsHTTPError(t *testing.T) {
 		HTTPClient: &http.Client{Transport: mockRT},
 		Host:       host,
 		PageSize:   100,
+		StatFn:     runhttp.StatFromContext,
 	}
 
 	assetChan, errChan := nexposeAssetFetcher.FetchAssets(context.Background(), "site67")
@@ -529,6 +539,7 @@ func TestFetchAssetsAssetPayloadToAssetEventError(t *testing.T) {
 		HTTPClient: &http.Client{Transport: mockRT},
 		Host:       host,
 		PageSize:   1,
+		StatFn:     runhttp.StatFromContext,
 	}
 
 	assetChan, errChan := nexposeAssetFetcher.FetchAssets(context.Background(), "site67")
@@ -582,6 +593,7 @@ func TestMakeRequestSuccess(t *testing.T) {
 		HTTPClient: &http.Client{Transport: mockRT},
 		Host:       host,
 		PageSize:   100,
+		StatFn:     runhttp.StatFromContext,
 	}
 
 	var wg sync.WaitGroup
@@ -612,6 +624,7 @@ func TestMakeRequestWithErrorReadingResponse(t *testing.T) {
 		HTTPClient: &http.Client{Transport: mockRT},
 		Host:       host,
 		PageSize:   100,
+		StatFn:     runhttp.StatFromContext,
 	}
 
 	var wg sync.WaitGroup
@@ -640,6 +653,7 @@ func TestMakeRequestHTTPError(t *testing.T) {
 		HTTPClient: &http.Client{Transport: mockRT},
 		Host:       host,
 		PageSize:   100,
+		StatFn:     runhttp.StatFromContext,
 	}
 
 	var wg sync.WaitGroup
@@ -677,6 +691,7 @@ func TestMakeRequestWithAssetPayloadToAssetEventError(t *testing.T) {
 		HTTPClient: &http.Client{Transport: mockRT},
 		Host:       host,
 		PageSize:   100,
+		StatFn:     runhttp.StatFromContext,
 	}
 
 	var wg sync.WaitGroup
@@ -712,6 +727,7 @@ func TestMakeRequestWithNoAssetsReturned(t *testing.T) {
 		HTTPClient: &http.Client{Transport: mockRT},
 		Host:       host,
 		PageSize:   100,
+		StatFn:     runhttp.StatFromContext,
 	}
 
 	var wg sync.WaitGroup
@@ -744,6 +760,7 @@ func TestMakeRequestWithNoResponse(t *testing.T) {
 	nexposeAssetFetcher := &NexposeAssetFetcher{
 		HTTPClient: &http.Client{Transport: mockRT},
 		Host:       host,
+		StatFn:     runhttp.StatFromContext,
 	}
 
 	var wg sync.WaitGroup
@@ -772,6 +789,7 @@ func TestMakeRequestWithNotOKStatus(t *testing.T) {
 	nexposeAssetFetcher := &NexposeAssetFetcher{
 		HTTPClient: &http.Client{Transport: mockRT},
 		Host:       host,
+		StatFn:     runhttp.StatFromContext,
 	}
 
 	var wg sync.WaitGroup
@@ -791,6 +809,7 @@ func TestNewNexposeSiteAssetsRequestSuccess(t *testing.T) {
 	assetFetcher := &NexposeAssetFetcher{
 		Host:     host,
 		PageSize: 100,
+		StatFn:   runhttp.StatFromContext,
 	}
 	req := assetFetcher.newNexposeSiteAssetsRequest("siteID", 1)
 
@@ -802,6 +821,7 @@ func TestNewNexposeSiteAssetsRequestWithExtraSlashes(t *testing.T) {
 	assetFetcher := &NexposeAssetFetcher{
 		Host:     host,
 		PageSize: 100,
+		StatFn:   runhttp.StatFromContext,
 	}
 	req := assetFetcher.newNexposeSiteAssetsRequest("/siteID/", 1)
 


### PR DESCRIPTION
… Nexpose Asset' out of the convert function, whose concern *should* just be to convert