### PR TITLE
SECD-740 Revert changing id to string

### DIFF
--- a/api-outbound.yaml
+++ b/api-outbound.yaml
@@ -246,8 +246,10 @@ components:
           format: date-time
           description: The last time the asset was scanned in ISO8601 format.
         id:
-          type: string
+          type: integer
+          format: int64
           description: The Nexpose identifier of the asset.
+          example: 67
         hostname:
           type: string
           description: The primary host name (local or FQDN) of the asset.
@@ -263,8 +265,10 @@ components:
           format: date-time
           description: The last time the asset was scanned in ISO8601 format.
         id:
-          type: string
+          type: integer
+          format: int64
           description: The Nexpose identifier of the asset.
+          example: 67
         ip:
           type: string
           description: The primary IPv4 or IPv6 address of the asset.


### PR DESCRIPTION
Reverting part of the last PR which accidentally changed the asset id field to a string.