### PR TITLE
SECD-740 Require either hostname or IP

### DIFF
--- a/pkg/assetfetcher/asset.go
+++ b/pkg/assetfetcher/asset.go
@@ -318,8 +318,8 @@ func (a Asset) AssetPayloadToAssetEvent() (domain.AssetEvent, error) {
 	if err != nil {
 		return domain.AssetEvent{}, err
 	}
-	if a.ID == 0 || a.IP == "" || lastScanned.IsZero() {
-		return domain.AssetEvent{}, &MissingRequiredFields{a.ID, a.IP, lastScanned}
+	if a.ID == 0 || (a.IP == "" && a.HostName == "") || lastScanned.IsZero() {
+		return domain.AssetEvent{}, &MissingRequiredFields{a.ID, a.IP, a.HostName, lastScanned}
 	}
 	return domain.AssetEvent{
 		ID:          a.ID,

--- a/pkg/assetfetcher/asset_test.go
+++ b/pkg/assetfetcher/asset_test.go
@@ -89,9 +89,8 @@ func TestAssetPayloadToAssetEventError(t *testing.T) {
 			},
 		},
 		{
-			"No IP",
+			"No IP or Hostname",
 			Asset{
-				ID:      1,
 				History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: "2019-04-22T15:02:44.000Z"}},
 			},
 		},
@@ -101,7 +100,7 @@ func TestAssetPayloadToAssetEventError(t *testing.T) {
 		t.Run(test.name, func(tt *testing.T) {
 			_, err := test.asset.AssetPayloadToAssetEvent()
 			lastScanned, _ := test.asset.History.lastScannedTimestamp()
-			assert.Equal(t, &MissingRequiredFields{test.asset.ID, test.asset.IP, lastScanned}, err)
+			assert.Equal(t, &MissingRequiredFields{test.asset.ID, test.asset.IP, test.asset.HostName, lastScanned}, err)
 
 		})
 	}
@@ -136,7 +135,7 @@ func TestAssetPayloadToAssetEventErrorNeverBeenScanned(t *testing.T) {
 			// test remains to ensure the function handles such a case appropriately
 			_, err := test.asset.AssetPayloadToAssetEvent()
 			var lastScanned time.Time // intentionally empty
-			assert.Equal(t, &MissingRequiredFields{test.asset.ID, test.asset.IP, lastScanned}, err)
+			assert.Equal(t, &MissingRequiredFields{test.asset.ID, test.asset.IP, test.asset.HostName, lastScanned}, err)
 		})
 	}
 }

--- a/pkg/assetfetcher/errors.go
+++ b/pkg/assetfetcher/errors.go
@@ -71,14 +71,15 @@ func (e *ErrorConvertingAssetPayload) Error() string {
 	return fmt.Sprintf("error converting asset %v payload to event %v", e.AssetID, e.Inner)
 }
 
-// MissingRequiredFields represents an error we get if the ID, IP, or lastScanned date is empty
+// MissingRequiredFields represents an error we get if the ID or lastScanned date is empty
 type MissingRequiredFields struct {
 	AssetID          int64
 	AssetIP          string
+	AssetHostname    string
 	AssetLastScanned time.Time
 }
 
 // Error returns an MissingRequiredFields
 func (e *MissingRequiredFields) Error() string {
-	return fmt.Sprintf("required fields are missing. ID: %v, IP: %s, LastScanned: %v", e.AssetID, e.AssetIP, e.AssetLastScanned)
+	return fmt.Sprintf("required fields are missing. ID: %v, IP: %s, Hostname: %s, LastScanned: %v", e.AssetID, e.AssetIP, e.AssetHostname, e.AssetLastScanned)
 }

--- a/pkg/assetfetcher/errors_test.go
+++ b/pkg/assetfetcher/errors_test.go
@@ -53,8 +53,8 @@ func TestAssetFetcherErrors(t *testing.T) {
 		},
 		{
 			"MissingRequiredFields",
-			&MissingRequiredFields{123456, "", lastScannedNow},
-			fmt.Sprintf("required fields are missing. ID: 123456, IP: , LastScanned: %v", lastScannedNow),
+			&MissingRequiredFields{123456, "ip", "host", lastScannedNow},
+			fmt.Sprintf("required fields are missing. ID: 123456, IP: ip, Hostname: host, LastScanned: %v", lastScannedNow),
 		},
 	}
 


### PR DESCRIPTION
Successfully scanned Nexpose assets don't necessarily have IPs, so only cases where an asset has neither a hostname nor an IP should be considered error cases.