### PR TITLE
SECD-746 Custom stats not emitting due to async mode

### DIFF
--- a/api-inbound.yaml
+++ b/api-inbound.yaml
@@ -61,8 +61,8 @@ paths:
             schema:
               $ref: '#/components/schemas/ScanNotification'
       responses:
-        "202":
-          description: "Accepted"
+        "204":
+          description: "No content"
         "400":
           description: "Invalid input"
           content:
@@ -77,9 +77,9 @@ paths:
           - "lambda"
         lambda:
           arn: "notification"
-          async: true
+          async: false
           request: '#! json .Request.Body !#'
-          success: '{"status": 202, "bodyPassthrough": true}'
+          success: '{"status": 204, "bodyPassthrough": true}'
           error: '{"status": 500, "bodyPassthrough": true}'
 components:
   schemas:


### PR DESCRIPTION
In the async case of [serverfull's invoke api](https://github.com/asecurityteam/serverfull/blob/master/invokeapi.go#L117), the base context is wrapped,
but when it gets cancelled, all parent/children contexts are unlinked. This
causes the logger/stater that's injected to fail. Disabling async mode for now.

Also adding a check for the status code of the first call to Nexpose.