### PR TITLE
Check status code on first call to Nexpose API in NexposeAssetFetcher

### DIFF
--- a/pkg/assetfetcher/http.go
+++ b/pkg/assetfetcher/http.go
@@ -82,6 +82,12 @@ func (c *NexposeAssetFetcher) FetchAssets(ctx context.Context, siteID string) (<
 		return nil, errChan
 	}
 
+	if res.StatusCode != http.StatusOK {
+		errChan <- &ErrorFetchingAssets{Inner: fmt.Errorf("unexpected response from nexpose: %d",
+			res.StatusCode)}
+		return nil, errChan
+	}
+
 	var siteAssetResp SiteAssetsResponse
 	if err := json.Unmarshal(respBody, &siteAssetResp); err != nil {
 		errChan <- &ErrorParsingJSONResponse{err, req.URL.String()}
@@ -141,8 +147,8 @@ func (c *NexposeAssetFetcher) makeRequest(ctx context.Context, wg *sync.WaitGrou
 	}
 
 	if res.StatusCode != http.StatusOK {
-		errChan <- &ErrorFetchingAssets{Inner: fmt.Errorf("unexpected response from nexpose: %d %s",
-			res.StatusCode, string(respBody))}
+		errChan <- &ErrorFetchingAssets{Inner: fmt.Errorf("unexpected response from nexpose: %d",
+			res.StatusCode)}
 		return
 	}
 	var siteAssetResp SiteAssetsResponse


### PR DESCRIPTION
Add an explicit check for a 200 response to the first call to the Nexpose API.
This check is already in place for all subsequent calls, which use the makeRequest
function.

Drops the response body from the logged output, as it provides limited value.