### PR TITLE
Secd 782/handle 0timestamp assets

### DIFF
--- a/pkg/assetfetcher/asset.go
+++ b/pkg/assetfetcher/asset.go
@@ -339,7 +339,8 @@ func (a assetHistoryEvents) lastScannedTimestamp() (time.Time, error) {
 			if err != nil {
 				return latestTime, err
 			}
-			if t.After(latestTime) {
+			// also need to make sure the date is not a 0 value
+			if t.After(latestTime) && !t.IsZero() {
 				latestTime = t
 			}
 		}

--- a/pkg/assetfetcher/asset.go
+++ b/pkg/assetfetcher/asset.go
@@ -313,12 +313,14 @@ type VulnerabilitySummary struct {
 // into an AssetEvent for downstream services.  Callers of this function are
 // expected to pass an Asset that cleanly maps to AssetEvent, meaning the
 // event must have a timestamp (because without one, it's not an event!)
+// It is guaranteed that when this function is called an asset will have a valid
+// scanned history
 func (a Asset) AssetPayloadToAssetEvent() (domain.AssetEvent, error) {
 	lastScanned, err := a.History.lastScannedTimestamp()
 	if err != nil {
 		return domain.AssetEvent{}, err
 	}
-	if a.ID == 0 || (a.IP == "" && a.HostName == "") || lastScanned.IsZero() {
+	if a.ID == 0 || (a.IP == "" && a.HostName == "") {
 		return domain.AssetEvent{}, &MissingRequiredFields{a.ID, a.IP, a.HostName, lastScanned}
 	}
 	return domain.AssetEvent{
@@ -331,6 +333,7 @@ func (a Asset) AssetPayloadToAssetEvent() (domain.AssetEvent, error) {
 
 type assetHistoryEvents []AssetHistory
 
+// by this point we should be guaranteed a valid SCAN history
 func (a assetHistoryEvents) lastScannedTimestamp() (time.Time, error) {
 	var latestTime time.Time
 	for _, evt := range a {
@@ -339,8 +342,7 @@ func (a assetHistoryEvents) lastScannedTimestamp() (time.Time, error) {
 			if err != nil {
 				return latestTime, err
 			}
-			// also need to make sure the date is not a 0 value
-			if t.After(latestTime) && !t.IsZero() {
+			if t.After(latestTime) {
 				latestTime = t
 			}
 		}

--- a/pkg/assetfetcher/asset.go
+++ b/pkg/assetfetcher/asset.go
@@ -313,7 +313,7 @@ type VulnerabilitySummary struct {
 // into an AssetEvent for downstream services.  Callers of this function are
 // expected to pass an Asset that cleanly maps to AssetEvent, meaning the
 // event must have a timestamp (because without one, it's not an event!)
-// It is guaranteed that when this function is called an asset will have a valid
+// It is expected that when this function is called an asset will have a valid
 // scanned history
 func (a Asset) AssetPayloadToAssetEvent() (domain.AssetEvent, error) {
 	lastScanned, err := a.History.lastScannedTimestamp()

--- a/pkg/assetfetcher/asset_test.go
+++ b/pkg/assetfetcher/asset_test.go
@@ -102,6 +102,13 @@ func TestAssetPayloadToAssetEventError(t *testing.T) {
 				History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: "2019-04-22T15:02:44.000Z"}},
 			},
 		},
+		{
+			"No LastScanned",
+			Asset{
+				ID: 1,
+				IP: "127.0.0.1",
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/assetfetcher/asset_test.go
+++ b/pkg/assetfetcher/asset_test.go
@@ -47,6 +47,30 @@ func TestLastAssessedForVulnerabilities(t *testing.T) {
 			time.Time{},
 			true,
 		},
+		{
+			"empty timestamp field",
+			assetHistoryEvents{
+				AssetHistory{Type: "SCAN", Date: ""},
+			},
+			time.Time{},
+			true,
+		},
+		{
+			"0 timestamp field",
+			assetHistoryEvents{
+				AssetHistory{Type: "SCAN", Date: "0001-01-01T00:00:00Z"},
+			},
+			time.Time{},
+			false,
+		},
+		{
+			"invalid time signature",
+			assetHistoryEvents{
+				AssetHistory{Type: "SCAN", Date: "2018-02-05 01:02:03 +1234 UTC"},
+			},
+			time.Time{},
+			true,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(tt *testing.T) {

--- a/pkg/assetfetcher/http.go
+++ b/pkg/assetfetcher/http.go
@@ -97,7 +97,6 @@ func (c *NexposeAssetFetcher) FetchAssets(ctx context.Context, siteID string) (<
 
 	pagedAssetChan := make(chan domain.AssetEvent, siteAssetResp.Page.TotalResources)
 	pagedErrChan := make(chan error, siteAssetResp.Page.TotalResources)
-
 	for _, asset := range siteAssetResp.Resources {
 		if !asset.hasBeenScanned() {
 			// no need to continue processing a Nexpose Asset that has never been scanned
@@ -186,10 +185,11 @@ func (a Asset) hasBeenScanned() bool {
 		if evt.Type == "SCAN" {
 			t, err := time.Parse(time.RFC3339, evt.Date)
 			// check if the date field is parsable and if it isn't 0 value
-			if err != nil && !t.IsZero() {
+			if err != nil || t.IsZero() {
 				continue
+			} else {
+				return true
 			}
-			return true
 		}
 	}
 	return false

--- a/pkg/assetfetcher/http.go
+++ b/pkg/assetfetcher/http.go
@@ -193,9 +193,8 @@ func (a Asset) hasBeenScanned() bool {
 			// check if the date field is parsable and if it isn't 0 value
 			if err != nil || t.IsZero() {
 				continue
-			} else {
-				return true
 			}
+			return true
 		}
 	}
 	return false

--- a/pkg/assetfetcher/http.go
+++ b/pkg/assetfetcher/http.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"path"
 	"sync"
+	"time"
 
 	"github.com/asecurityteam/nexpose-asset-producer/pkg/domain"
 )
@@ -183,6 +184,11 @@ func (c *NexposeAssetFetcher) newNexposeSiteAssetsRequest(siteID string, page in
 func (a Asset) hasBeenScanned() bool {
 	for _, evt := range a.History {
 		if evt.Type == "SCAN" {
+			t, err := time.Parse(time.RFC3339, evt.Date)
+			// check if the date field is parsable and if it isn't 0 value
+			if err != nil && !t.IsZero() {
+				continue
+			}
 			return true
 		}
 	}

--- a/pkg/assetfetcher/http_test.go
+++ b/pkg/assetfetcher/http_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/asecurityteam/nexpose-asset-producer/pkg/domain"
 	"github.com/asecurityteam/runhttp"
@@ -545,7 +546,7 @@ func TestFetchAssetsAssetPayloadToAssetEventError(t *testing.T) {
 	mockRT := NewMockRoundTripper(ctrl)
 
 	resp := SiteAssetsResponse{
-		Resources: []Asset{{History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: "not a time"}}}},
+		Resources: []Asset{{History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: "2019-05-14T15:03:47.000Z"}}}},
 		Page: Page{
 			TotalPages:     1,
 			TotalResources: 1,
@@ -572,6 +573,7 @@ func TestFetchAssetsAssetPayloadToAssetEventError(t *testing.T) {
 	for {
 		select {
 		case respAsset, ok := <-assetChan:
+
 			if !ok {
 				assetChan = nil
 			} else {
@@ -700,7 +702,7 @@ func TestMakeRequestWithAssetPayloadToAssetEventError(t *testing.T) {
 	defer ctrl.Finish()
 	mockRT := NewMockRoundTripper(ctrl)
 	resp := SiteAssetsResponse{
-		Resources: []Asset{{History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: "not a time"}}}},
+		Resources: []Asset{{History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: "0001-01-01T00:00:00Z"}, AssetHistory{Type: "SCAN", Date: "not a time"}}}},
 		Page:      Page{},
 	}
 	respJSON, _ := json.Marshal(resp)
@@ -849,4 +851,19 @@ func TestNewNexposeSiteAssetsRequestWithExtraSlashes(t *testing.T) {
 	req := assetFetcher.newNexposeSiteAssetsRequest("/siteID/", 1)
 
 	assert.Equal(t, "http://localhost/api/3/sites/siteID/assets?page=1&size=100", req.URL.String())
+}
+func TestHasBeenScannedBadTimeField(t *testing.T) {
+	dummyAssetBlankTimeStamp := Asset{History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: ""}}}
+	assert.Equal(t, dummyAssetBlankTimeStamp.hasBeenScanned(), false)
+
+	dummyAssetInvalidTimeStamp := Asset{History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: time.Time{}.String()}}}
+	assert.Equal(t, dummyAssetInvalidTimeStamp.hasBeenScanned(), false)
+
+	dummyAssetZeroValueTimeStamp := Asset{History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: "0001-01-01T00:00:00Z"}}}
+	assert.Equal(t, dummyAssetZeroValueTimeStamp.hasBeenScanned(), false)
+}
+
+func TestHasBeenScannedValidHistory(t *testing.T) {
+	dummyAssetValidHistory := Asset{History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: "not a time"}, AssetHistory{Type: "SCAN", Date: "2019-04-22T15:02:44.000Z"}}}
+	assert.Equal(t, dummyAssetValidHistory.hasBeenScanned(), true)
 }

--- a/pkg/assetfetcher/http_test.go
+++ b/pkg/assetfetcher/http_test.go
@@ -852,19 +852,39 @@ func TestNewNexposeSiteAssetsRequestWithExtraSlashes(t *testing.T) {
 
 	assert.Equal(t, "http://localhost/api/3/sites/siteID/assets?page=1&size=100", req.URL.String())
 }
-func TestHasBeenScannedBadTimeField(t *testing.T) {
-	dummyAssetBlankTimeStamp := Asset{History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: ""}}}
-	assert.Equal(t, dummyAssetBlankTimeStamp.hasBeenScanned(), false)
+func TestHasBeenScanned(t *testing.T) {
 
-	// time.Time{}.String() is not a valid format for conversion to time.RFC3339
-	dummyAssetInvalidTimeStamp := Asset{History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: time.Time{}.String()}}}
-	assert.Equal(t, dummyAssetInvalidTimeStamp.hasBeenScanned(), false)
+	tests := []struct {
+		name     string
+		asset    Asset
+		expected bool
+	}{
+		{
+			"dummyAssetBlankTimeStamp",
+			Asset{History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: ""}}},
+			false,
+		},
+		{
+			"dummyAssetInvalidTimeStamp",
+			Asset{History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: time.Time{}.String()}}},
+			false,
+		},
+		{
+			"dummyAssetZeroValueTimeStamp",
+			Asset{History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: "0001-01-01T00:00:00Z"}}},
+			false,
+		},
+		{
+			"dummyAssetValidHistory",
+			Asset{History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: "not a time"}, AssetHistory{Type: "SCAN", Date: "2019-04-22T15:02:44.000Z"}}},
+			true,
+		},
+	}
 
-	dummyAssetZeroValueTimeStamp := Asset{History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: "0001-01-01T00:00:00Z"}}}
-	assert.Equal(t, dummyAssetZeroValueTimeStamp.hasBeenScanned(), false)
-}
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			assert.Equal(t, test.asset.hasBeenScanned(), test.expected)
+		})
+	}
 
-func TestHasBeenScannedValidHistory(t *testing.T) {
-	dummyAssetValidHistory := Asset{History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: "not a time"}, AssetHistory{Type: "SCAN", Date: "2019-04-22T15:02:44.000Z"}}}
-	assert.Equal(t, dummyAssetValidHistory.hasBeenScanned(), true)
 }

--- a/pkg/assetfetcher/http_test.go
+++ b/pkg/assetfetcher/http_test.go
@@ -702,7 +702,7 @@ func TestMakeRequestWithAssetPayloadToAssetEventError(t *testing.T) {
 	defer ctrl.Finish()
 	mockRT := NewMockRoundTripper(ctrl)
 	resp := SiteAssetsResponse{
-		Resources: []Asset{{History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: "0001-01-01T00:00:00Z"}, AssetHistory{Type: "SCAN", Date: "not a time"}}}},
+		Resources: []Asset{{History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: "1234-12-01T00:00:00Z"}}}},
 		Page:      Page{},
 	}
 	respJSON, _ := json.Marshal(resp)
@@ -856,6 +856,7 @@ func TestHasBeenScannedBadTimeField(t *testing.T) {
 	dummyAssetBlankTimeStamp := Asset{History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: ""}}}
 	assert.Equal(t, dummyAssetBlankTimeStamp.hasBeenScanned(), false)
 
+	// time.Time{}.String() is not a valid format for conversion to time.RFC3339
 	dummyAssetInvalidTimeStamp := Asset{History: assetHistoryEvents{AssetHistory{Type: "SCAN", Date: time.Time{}.String()}}}
 	assert.Equal(t, dummyAssetInvalidTimeStamp.hasBeenScanned(), false)
 


### PR DESCRIPTION
This branch is intended to apprehend bad Asset histories, specifically those that are labeled as "SCAN" but have a blank timestamp. If a timestamp is blank, it automatically gets initialized with a 0 value time, thus we need to have a stricter check.