### PR TITLE
deleted warning log, and custom stats

### DIFF
--- a/pkg/handlers/v1/nexposeassetproducer.go
+++ b/pkg/handlers/v1/nexposeassetproducer.go
@@ -44,7 +44,7 @@ func (h *NexposeScannedAssetProducer) Handle(ctx context.Context, in ScanInfo) e
 	stater.Count("totalassets", float64(len(totalAssets)), fmt.Sprintf("site:%s", in.SiteID))
 
 	var totalAssetsProduced float64
-	validAssets, invalidAssets := h.AssetValidator.ValidateAssets(ctx, totalAssets, in.ScanID)
+	validAssets, _ := h.AssetValidator.ValidateAssets(ctx, totalAssets, in.ScanID)
 	for _, validAsset := range validAssets {
 		err := h.Producer.Produce(ctx, validAsset)
 		if err != nil {
@@ -60,47 +60,6 @@ func (h *NexposeScannedAssetProducer) Handle(ctx context.Context, in ScanInfo) e
 
 	}
 	stater.Count("totalassetsproduced", totalAssetsProduced, fmt.Sprintf("site:%s", in.SiteID))
-	for _, validationErr := range invalidAssets {
-		var warningLog interface{}
-		switch validationErr.(type) {
-		case *domain.ScanIDForLastScanNotInAssetHistory:
-			validationErr := validationErr.(*domain.ScanIDForLastScanNotInAssetHistory)
-			warningLog = logs.AssetValidateFail{
-				Reason:        validationErr.Error(),
-				AssetID:       validationErr.AssetID,
-				AssetIP:       validationErr.AssetIP,
-				AssetHostname: validationErr.AssetHostname,
-				SiteID:        in.SiteID,
-			}
-			stater.Count("assetskipped", 1, fmt.Sprintf("site:%s", in.SiteID), fmt.Sprintf("reason:%s", "noscantimeforscanid"))
-		case *domain.InvalidScanTime:
-			validationErr := validationErr.(*domain.InvalidScanTime)
-			warningLog = logs.AssetValidateFail{
-				Reason:        validationErr.Error(),
-				AssetID:       validationErr.AssetID,
-				AssetIP:       validationErr.AssetIP,
-				AssetHostname: validationErr.AssetHostname,
-				SiteID:        in.SiteID,
-			}
-			stater.Count("assetskipped", 1, fmt.Sprintf("site:%s", in.SiteID), fmt.Sprintf("reason:%s", "invalidscantime"))
-		case *domain.MissingRequiredInformation:
-			validationErr := validationErr.(*domain.MissingRequiredInformation)
-			warningLog = logs.AssetValidateFail{
-				Reason:        validationErr.Error(),
-				AssetID:       validationErr.AssetID,
-				AssetIP:       validationErr.AssetIP,
-				AssetHostname: validationErr.AssetHostname,
-				SiteID:        in.SiteID,
-			}
-			stater.Count("assetskipped", 1, fmt.Sprintf("site:%s", in.SiteID), fmt.Sprintf("reason:%s", "missingfields"))
-		default:
-			warningLog = logs.AssetValidateFail{
-				Reason: validationErr.Error(),
-				SiteID: in.SiteID,
-			}
-			stater.Count("assetskipped", 1, fmt.Sprintf("site:%s", in.SiteID), fmt.Sprintf("reason:%s", "unknown"))
-		}
-		logger.Warn(warningLog)
-	}
+
 	return nil
 }

--- a/pkg/handlers/v1/nexposeassetproducer_test.go
+++ b/pkg/handlers/v1/nexposeassetproducer_test.go
@@ -187,7 +187,6 @@ func TestNexposeAssetProducerHandlerMultipleErrors(t *testing.T) {
 
 	mockAssetFetcher.EXPECT().FetchAssets(gomock.Any(), "12345").Return(assetList, nil)
 	mockAssetValidator.EXPECT().ValidateAssets(gomock.Any(), assetList, scanID).Return(validAssetList, errorList)
-	mockLogger.EXPECT().Warn(gomock.Any()).Times(4)
 
 	handler := NexposeScannedAssetProducer{
 		Producer:       mockProducer,


### PR DESCRIPTION
This PR is to address PSD-490:
- deleted warning logs
- because `ScanIDForLastScanNotInAssetHistory` is the only scenario we've been getting the past week in our logs, I took the liberty of removing the entire iteration of invalid assets
-deleted custom metrics for skipped assets