### PR TITLE
PSD 504/query assets by last scan date

### DIFF
--- a/api-outbound.yaml
+++ b/api-outbound.yaml
@@ -49,16 +49,10 @@ info:
     name: Apache 2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
 paths:
-  /api/3/sites/{siteID}/assets:
-    get:
-      description: Nexpose API for retrieving paged assets linked with the specified site.
+  /api/3/assets/search:
+    post:
+      summary: Nexpose API for retrieving assets based upon filtered search criteria
       parameters:
-        - name: siteID
-          in: path
-          description: The identifier of the site.
-          required: true
-          schema:
-            type: integer
         - name: page
           in: query
           description: "The index of the page (zero-based) to retrieve."
@@ -71,6 +65,12 @@ paths:
           required: false
           schema:
             type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NexposeAssetSearchRequestBody' 
       responses:
         200:
           description: "Success"
@@ -91,35 +91,41 @@ paths:
               schema:
                 $ref: '#/components/schemas/NexposeError'
       x-transportd:
-        backend: nexpose
-        enabled:
-          - "accesslog"
-          - "requestvalidation"
-          - "responsevalidation"
-          - "timeout"
-          - "retry"
-          - "basicauth"
-        timeout:
-          after: "2s"
-        retry:
-          backoff: "50ms"
-          limit: 3
-          codes:
-            - 500
-            - 501
-            - 502
-            - 503
-            - 504
-            - 505
-            - 506
-            - 507
-            - 508
-            - 509
-            - 510
-            - 511
-        basicauth:
-          username: "${NEXPOSE_API_USERNAME}"
-          password: "${NEXPOSE_API_PASSWORD}"
+          backend: nexpose
+          enabled:
+            - "accesslog"
+            - "metrics"
+            - "requestheaderinject"
+            - "requestvalidation"
+            - "responsevalidation"
+            - "timeout"
+            - "retry"
+            - "basicauth"
+          timeout:
+            after: "30s"
+          requestheaderinject:
+            headers:
+              Content-Type:
+              - "application/json"
+          retry:
+            backoff: "3s"
+            limit: 3
+            codes:
+              - 500
+              - 501
+              - 502
+              - 503
+              - 504
+              - 505
+              - 506
+              - 507
+              - 508
+              - 509
+              - 510
+              - 511
+          basicauth:
+            username: "${NEXPOSE_USERNAME}"
+            password: "${NEXPOSE_PASSWORD}"
   /api/3:
     get:
       description: Nexpose API root endpoint, used for verifying if Nexpose can be reached
@@ -278,7 +284,37 @@ components:
           description: The date the asset information was collected or changed.
         scanId:
           type: integer
-          descrtion: If a scan-oriented change, the identifier of the corresponding scan the asset was scanned in.
+          description: If a scan-oriented change, the identifier of the corresponding scan the asset was scanned in.
+    NexposeAssetSearchRequestBody:
+      type: object
+      description: The request body for the Nexpose Asset Search API
+      required:
+        - filters
+        - match
+      properties:
+        filters:
+          type: array
+          items:
+              $ref: '#/components/schemas/NexposeSearchCriteria'
+        match:
+          type: string
+    NexposeSearchCriteria:
+      type: object
+      description: Nexpose search criteria for filtering
+      required:
+        - field
+        - operator
+      properties:
+        field:
+          type: string
+        operator:
+          type: string
+        value:
+          type: string
+        values:
+          type: array
+          items:
+            type: string
     NexposeError:
       type: object
       properties:

--- a/pkg/assetfetcher/http.go
+++ b/pkg/assetfetcher/http.go
@@ -14,8 +14,7 @@ import (
 	"github.com/asecurityteam/nexpose-asset-producer/pkg/domain"
 )
 
-// This const block helps format our request to the Nexpose sites asset endpoint and the asset search endpoint:
-// GET /api/3/sites/{id}/assets (doc: https://help.rapid7.com/insightvm/en-us/api/index.html#operation/getSiteAssets)
+// This const block helps format our request to the Nexpose asset search endpoint:
 // POST /api/3/assets/search (doc: https://help.rapid7.com/insightvm/en-us/api/index.html#operation/findAssets)
 const (
 	allMatch           = "all"

--- a/pkg/assetfetcher/http.go
+++ b/pkg/assetfetcher/http.go
@@ -204,7 +204,7 @@ func (c *NexposeAssetFetcher) newNexposeAssetsSearchRequest(siteID string, page 
 
 	requestBody, err := json.Marshal(payload)
 	if err != nil {
-		return nil, &domain.URLParsingError{Inner: err, NexposeURL: u.String()}
+		return nil, err
 	}
 
 	req, err := http.NewRequest(http.MethodPost, u.String(), bytes.NewBuffer(requestBody))

--- a/pkg/assetfetcher/http.go
+++ b/pkg/assetfetcher/http.go
@@ -22,7 +22,6 @@ const (
 	basePath           = "/api/3"
 	isOnOrAferOperator = "is-on-or-after"
 	inOperator         = "in"
-	nexposeSite        = "/sites"
 	nexposeAssets      = "/assets"
 	nexposeSearch      = "/search"
 	pageQueryParam     = "page" // The index of the page (zero-based) to retrieve.
@@ -147,23 +146,6 @@ func (c *NexposeAssetFetcher) fetchNexposeSiteAssetsPage(ctx context.Context, pa
 	}
 
 	return siteAssetResp, nil
-}
-
-// newNexposeSiteAssetsRequest builds URL we'll use to make the request to Nexpose's site assets endpoint
-func (c *NexposeAssetFetcher) newNexposeSiteAssetsRequest(siteID string, page int) (*http.Request, error) {
-	u, _ := url.Parse(c.Host.String())
-	u.Path = path.Join(u.Path, basePath, nexposeSite, siteID, nexposeAssets)
-	q := u.Query()
-	q.Set(pageQueryParam, fmt.Sprint(page))
-	q.Set(sizeQueryParam, fmt.Sprint(c.PageSize))
-	u.RawQuery = q.Encode()
-	// the only time http.NewRequest returns an error is if there's a parsing error,
-	// which we already checked for earlier, so no need to check it again
-	req, err := http.NewRequest(http.MethodGet, u.String(), http.NoBody)
-	if err != nil {
-		return nil, &domain.URLParsingError{Inner: err, NexposeURL: u.String()}
-	}
-	return req, nil
 }
 
 // newNexposeAssetsSearchRequest builds the request for the Nexpose Assets API and using the passed in siteID

--- a/pkg/assetfetcher/http_test.go
+++ b/pkg/assetfetcher/http_test.go
@@ -234,6 +234,18 @@ func TestNewNexposeSiteAssetsRequestWithExtraSlashes(t *testing.T) {
 	assert.Equal(t, "http://localhost/api/3/sites/siteID/assets?page=1&size=100", req.URL.String())
 }
 
+func TestNewNexposeAssetsSearchRequestSuccess(t *testing.T) {
+	host, _ := url.Parse("http://localhost")
+	assetFetcher := &NexposeAssetFetcher{
+		Host:     host,
+		PageSize: 100,
+		StatFn:   MockStatFn,
+	}
+	req, err := assetFetcher.newNexposeAssetsSearchRequest("siteID", 1)
+	assert.Nil(t, err)
+	assert.Equal(t, "http://localhost/api/3/assets/search?page=1&size=100", req.URL.String())
+}
+
 func TestCheckDependenciesSuccess(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockRT := NewMockRoundTripper(ctrl)

--- a/pkg/assetfetcher/http_test.go
+++ b/pkg/assetfetcher/http_test.go
@@ -210,30 +210,6 @@ func TestFetchAssetsHTTPError(t *testing.T) {
 	assert.IsType(t, &domain.NexposeHTTPRequestError{}, err)
 }
 
-func TestNewNexposeSiteAssetsRequestSuccess(t *testing.T) {
-	host, _ := url.Parse("http://localhost")
-	assetFetcher := &NexposeAssetFetcher{
-		Host:     host,
-		PageSize: 100,
-		StatFn:   MockStatFn,
-	}
-	req, err := assetFetcher.newNexposeSiteAssetsRequest("siteID", 1)
-	assert.Nil(t, err)
-	assert.Equal(t, "http://localhost/api/3/sites/siteID/assets?page=1&size=100", req.URL.String())
-}
-
-func TestNewNexposeSiteAssetsRequestWithExtraSlashes(t *testing.T) {
-	host, _ := url.Parse("http://localhost")
-	assetFetcher := &NexposeAssetFetcher{
-		Host:     host,
-		PageSize: 100,
-		StatFn:   MockStatFn,
-	}
-	req, err := assetFetcher.newNexposeSiteAssetsRequest("/siteID/", 1)
-	assert.Nil(t, err)
-	assert.Equal(t, "http://localhost/api/3/sites/siteID/assets?page=1&size=100", req.URL.String())
-}
-
 func TestNewNexposeAssetsSearchRequestSuccess(t *testing.T) {
 	host, _ := url.Parse("http://localhost")
 	assetFetcher := &NexposeAssetFetcher{
@@ -242,6 +218,18 @@ func TestNewNexposeAssetsSearchRequestSuccess(t *testing.T) {
 		StatFn:   MockStatFn,
 	}
 	req, err := assetFetcher.newNexposeAssetsSearchRequest("siteID", 1)
+	assert.Nil(t, err)
+	assert.Equal(t, "http://localhost/api/3/assets/search?page=1&size=100", req.URL.String())
+}
+
+func TestNewNexposeAssetsSearchRequestWithExtraSlashes(t *testing.T) {
+	host, _ := url.Parse("http://localhost")
+	assetFetcher := &NexposeAssetFetcher{
+		Host:     host,
+		PageSize: 100,
+		StatFn:   MockStatFn,
+	}
+	req, err := assetFetcher.newNexposeAssetsSearchRequest("/siteID/", 1)
 	assert.Nil(t, err)
 	assert.Equal(t, "http://localhost/api/3/assets/search?page=1&size=100", req.URL.String())
 }


### PR DESCRIPTION
PSD 504 removes the Nexpose site endpoint and replaces it with the asset search endpoint. In so doing, it will now query for assets that have been scanned as of the current date when the scan notification was received minus one day. This will reduce the amount of assets being returned and in so doing reducing the load on Nexpose.