### PR TITLE
Psd 762/add exception to agent scans

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,7 +24,7 @@ services:
       SERVERFULL_RUNTIME_SIGNALS_OS_SIGNALS: 15 2
       NEXPOSE_HOST: http://gateway-outbound:8082
       NEXPOSE_PAGESIZE: 100
-      NEXPOSEVALIDATOR_AGENTSITE: 2
+      NEXPOSEVALIDATOR_AGENTSITE: "2"
       HTTPPRODUCER_ENDPOINT: http://gateway-outbound:8082/publish
   gateway-inbound:
     build:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,6 +24,7 @@ services:
       SERVERFULL_RUNTIME_SIGNALS_OS_SIGNALS: 15 2
       NEXPOSE_HOST: http://gateway-outbound:8082
       NEXPOSE_PAGESIZE: 100
+      NEXPOSEVALIDATOR_AGENTSITE: 2
       HTTPPRODUCER_ENDPOINT: http://gateway-outbound:8082/publish
   gateway-inbound:
     build:

--- a/pkg/assetvalidator/config.go
+++ b/pkg/assetvalidator/config.go
@@ -7,6 +7,7 @@ import (
 // AssetValidatorConfig holds configuration that validates
 // assets from Nexpose
 type AssetValidatorConfig struct {
+	AgentSite string
 }
 
 // Name is used by the settings library and will add a "NEXPOSEVALIDATOR_"
@@ -27,5 +28,7 @@ func (*AssetValidatorComponent) Settings() *AssetValidatorConfig {
 // New constructs a NexposeAssetValidator from a config.
 func (*AssetValidatorComponent) New(_ context.Context, c *AssetValidatorConfig) (*NexposeAssetValidator, error) {
 
-	return &NexposeAssetValidator{}, nil
+	return &NexposeAssetValidator{
+		AgentSite: c.AgentSite,
+	}, nil
 }

--- a/pkg/assetvalidator/validateAssets.go
+++ b/pkg/assetvalidator/validateAssets.go
@@ -11,15 +11,16 @@ import (
 
 // NexposeAssetValidator is used to validate a list of retrieved Assets
 type NexposeAssetValidator struct {
+	AgentSite string
 }
 
 // ValidateAssets takes in a list of assets from Nexpose, and returns a list of valid Asset events, and a list of errors based
 // on defined validation rules
-func (v *NexposeAssetValidator) ValidateAssets(ctx context.Context, assets []domain.Asset, scanID string) ([]domain.AssetEvent, []error) {
+func (v *NexposeAssetValidator) ValidateAssets(ctx context.Context, assets []domain.Asset, scanID string, siteID string) ([]domain.AssetEvent, []error) {
 	assetEventListList := []domain.AssetEvent{}
 	errorList := []error{}
 	for _, asset := range assets {
-		scanTime, err := v.getScanTime(asset, scanID)
+		scanTime, err := v.getScanTime(asset, scanID, siteID)
 		if err != nil {
 			errorList = append(errorList, err)
 			continue
@@ -36,16 +37,19 @@ func (v *NexposeAssetValidator) ValidateAssets(ctx context.Context, assets []dom
 
 // getScanTime searches through the asset's event history for a scan event with the ScanID
 // that matches the ScanID of the scan completion event that triggered the pipeline.
-func (v *NexposeAssetValidator) getScanTime(asset domain.Asset, scanID string) (time.Time, error) {
+func (v *NexposeAssetValidator) getScanTime(asset domain.Asset, scanID string, siteID string) (time.Time, error) {
 	for _, evt := range asset.History {
 		if evt.Type == "SCAN" {
-			if strconv.FormatInt(evt.ScanID, 10) == scanID {
+			if strconv.FormatInt(evt.ScanID, 10) == scanID || siteID == v.AgentSite {
 				scanTime, err := time.Parse(time.RFC3339, evt.Date)
 				if err != nil {
 					return time.Time{}, &domain.InvalidScanTime{ScanID: scanID, ScanTime: scanTime, AssetID: asset.ID, AssetIP: asset.IP, AssetHostname: asset.HostName, Inner: err}
 				}
 				if scanTime.IsZero() {
 					return time.Time{}, &domain.InvalidScanTime{ScanID: scanID, ScanTime: scanTime, AssetID: asset.ID, AssetIP: asset.IP, AssetHostname: asset.HostName, Inner: errors.New("scan time is zero")}
+				}
+				if siteID == v.AgentSite && time.Since(scanTime).Hours() > 24 { // agent scans often lack scanIDs, so we validate them based on recency instead.
+					return time.Time{}, &domain.InvalidScanTime{ScanID: scanID, ScanTime: scanTime, AssetID: asset.ID, AssetIP: asset.IP, AssetHostname: asset.HostName, Inner: errors.New("agent scan is more than one day old")}
 				}
 				return scanTime, nil
 			}

--- a/pkg/assetvalidator/validateAssets_test.go
+++ b/pkg/assetvalidator/validateAssets_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAssetValidation(t *testing.T) {
 
-	nowish := time.Now().Round(time.Hour)
+	nowish, _ := time.Parse(time.RFC3339, time.Now().Round(time.Hour).Format(time.RFC3339)) // creates a reliable time.time object without a location value
 
 	tests := []struct {
 		name                         string

--- a/pkg/assetvalidator/validateAssets_test.go
+++ b/pkg/assetvalidator/validateAssets_test.go
@@ -197,7 +197,7 @@ func TestAssetValidation(t *testing.T) {
 			}
 			assetEventList, errorList := validator.ValidateAssets(context.Background(), test.assetList, "6", test.siteID)
 			assert.Equal(t, test.expectedDomainAssetEventList, assetEventList)
-			assert.IsType(t, test.expectedErrorList, errorList)
+			assert.Equal(t, len(test.expectedErrorList), len(errorList))
 		})
 	}
 }

--- a/pkg/domain/assetValidator.go
+++ b/pkg/domain/assetValidator.go
@@ -7,5 +7,5 @@ import (
 // AssetValidator represents the interface you can use to validate all Assets. It returns
 // a list of valid assets and a list of errors that reflect invalid assets
 type AssetValidator interface {
-	ValidateAssets(ctx context.Context, assets []Asset, scanID string) ([]AssetEvent, []error)
+	ValidateAssets(ctx context.Context, assets []Asset, scanID string, siteID string) ([]AssetEvent, []error)
 }

--- a/pkg/handlers/v1/mock_validateassets.go
+++ b/pkg/handlers/v1/mock_validateassets.go
@@ -35,16 +35,16 @@ func (m *MockAssetValidator) EXPECT() *MockAssetValidatorMockRecorder {
 }
 
 // ValidateAssets mocks base method
-func (m *MockAssetValidator) ValidateAssets(ctx context.Context, assets []domain.Asset, scanID string) ([]domain.AssetEvent, []error) {
+func (m *MockAssetValidator) ValidateAssets(ctx context.Context, assets []domain.Asset, scanID string, siteID string) ([]domain.AssetEvent, []error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ValidateAssets", ctx, assets, scanID)
+	ret := m.ctrl.Call(m, "ValidateAssets", ctx, assets, scanID, siteID)
 	ret0, _ := ret[0].([]domain.AssetEvent)
 	ret1, _ := ret[1].([]error)
 	return ret0, ret1
 }
 
 // ValidateAssets indicates an expected call of ValidateAssets
-func (mr *MockAssetValidatorMockRecorder) ValidateAssets(ctx, assets, scanID interface{}) *gomock.Call {
+func (mr *MockAssetValidatorMockRecorder) ValidateAssets(ctx, assets, scanID interface{}, siteID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateAssets", reflect.TypeOf((*MockAssetValidator)(nil).ValidateAssets), ctx, assets, scanID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateAssets", reflect.TypeOf((*MockAssetValidator)(nil).ValidateAssets), ctx, assets, scanID, siteID)
 }

--- a/pkg/handlers/v1/nexposeassetproducer.go
+++ b/pkg/handlers/v1/nexposeassetproducer.go
@@ -44,7 +44,7 @@ func (h *NexposeScannedAssetProducer) Handle(ctx context.Context, in ScanInfo) e
 	stater.Count("totalassets", float64(len(totalAssets)), fmt.Sprintf("site:%s", in.SiteID))
 
 	var totalAssetsProduced float64
-	validAssets, _ := h.AssetValidator.ValidateAssets(ctx, totalAssets, in.ScanID, in.SiteID)
+	validAssets, invalidAssets := h.AssetValidator.ValidateAssets(ctx, totalAssets, in.ScanID, in.SiteID)
 	for _, validAsset := range validAssets {
 		err := h.Producer.Produce(ctx, validAsset)
 		if err != nil {
@@ -60,6 +60,48 @@ func (h *NexposeScannedAssetProducer) Handle(ctx context.Context, in ScanInfo) e
 
 	}
 	stater.Count("totalassetsproduced", totalAssetsProduced, fmt.Sprintf("site:%s", in.SiteID))
+	for _, validationErr := range invalidAssets {
+		var warningLog interface{}
+		switch validationErr.(type) {
+		case *domain.ScanIDForLastScanNotInAssetHistory:
+			validationErr := validationErr.(*domain.ScanIDForLastScanNotInAssetHistory)
+			warningLog = logs.AssetValidateFail{
+				Reason:        validationErr.Error(),
+				AssetID:       validationErr.AssetID,
+				AssetIP:       validationErr.AssetIP,
+				AssetHostname: validationErr.AssetHostname,
+				SiteID:        in.SiteID,
+			}
+			stater.Count("assetskipped", 1, fmt.Sprintf("site:%s", in.SiteID), fmt.Sprintf("reason:%s", "noscantimeforscanid"))
+		case *domain.InvalidScanTime:
+			validationErr := validationErr.(*domain.InvalidScanTime)
+			warningLog = logs.AssetValidateFail{
+				Reason:        validationErr.Error(),
+				AssetID:       validationErr.AssetID,
+				AssetIP:       validationErr.AssetIP,
+				AssetHostname: validationErr.AssetHostname,
+				SiteID:        in.SiteID,
+			}
+			stater.Count("assetskipped", 1, fmt.Sprintf("site:%s", in.SiteID), fmt.Sprintf("reason:%s", "invalidscantime"))
+		case *domain.MissingRequiredInformation:
+			validationErr := validationErr.(*domain.MissingRequiredInformation)
+			warningLog = logs.AssetValidateFail{
+				Reason:        validationErr.Error(),
+				AssetID:       validationErr.AssetID,
+				AssetIP:       validationErr.AssetIP,
+				AssetHostname: validationErr.AssetHostname,
+				SiteID:        in.SiteID,
+			}
+			stater.Count("assetskipped", 1, fmt.Sprintf("site:%s", in.SiteID), fmt.Sprintf("reason:%s", "missingfields"))
+		default:
+			warningLog = logs.AssetValidateFail{
+				Reason: validationErr.Error(),
+				SiteID: in.SiteID,
+			}
+			stater.Count("assetskipped", 1, fmt.Sprintf("site:%s", in.SiteID), fmt.Sprintf("reason:%s", "unknown"))
+		}
+		logger.Warn(warningLog)
+	}
 
 	return nil
 }

--- a/pkg/handlers/v1/nexposeassetproducer.go
+++ b/pkg/handlers/v1/nexposeassetproducer.go
@@ -44,7 +44,7 @@ func (h *NexposeScannedAssetProducer) Handle(ctx context.Context, in ScanInfo) e
 	stater.Count("totalassets", float64(len(totalAssets)), fmt.Sprintf("site:%s", in.SiteID))
 
 	var totalAssetsProduced float64
-	validAssets, _ := h.AssetValidator.ValidateAssets(ctx, totalAssets, in.ScanID)
+	validAssets, _ := h.AssetValidator.ValidateAssets(ctx, totalAssets, in.ScanID, in.SiteID)
 	for _, validAsset := range validAssets {
 		err := h.Producer.Produce(ctx, validAsset)
 		if err != nil {

--- a/pkg/handlers/v1/nexposeassetproducer_test.go
+++ b/pkg/handlers/v1/nexposeassetproducer_test.go
@@ -187,6 +187,7 @@ func TestNexposeAssetProducerHandlerMultipleErrors(t *testing.T) {
 
 	mockAssetFetcher.EXPECT().FetchAssets(gomock.Any(), "12345").Return(assetList, nil)
 	mockAssetValidator.EXPECT().ValidateAssets(gomock.Any(), assetList, scanID, gomock.Any()).Return(validAssetList, errorList)
+	mockLogger.EXPECT().Warn(gomock.Any()).Times(4)
 
 	handler := NexposeScannedAssetProducer{
 		Producer:       mockProducer,

--- a/pkg/handlers/v1/nexposeassetproducer_test.go
+++ b/pkg/handlers/v1/nexposeassetproducer_test.go
@@ -29,7 +29,7 @@ func TestNexposeAssetProducerHandler(t *testing.T) {
 	validAssetList := []domain.AssetEvent{assetEvent}
 
 	mockAssetFetcher.EXPECT().FetchAssets(gomock.Any(), "12345").Return(assetList, nil)
-	mockAssetValidator.EXPECT().ValidateAssets(gomock.Any(), assetList, "1").Return(validAssetList, []error{})
+	mockAssetValidator.EXPECT().ValidateAssets(gomock.Any(), assetList, "1", gomock.Any()).Return(validAssetList, []error{})
 	mockProducer.EXPECT().Produce(gomock.Any(), gomock.Any()).Return(nil)
 
 	handler := NexposeScannedAssetProducer{
@@ -71,7 +71,7 @@ func TestNexposeAssetProducerHandlerMultipleAssets(t *testing.T) {
 	}
 
 	mockAssetFetcher.EXPECT().FetchAssets(gomock.Any(), siteID).Return(assetList, nil)
-	mockAssetValidator.EXPECT().ValidateAssets(gomock.Any(), assetList, scanID).Return(validAssetList, []error{})
+	mockAssetValidator.EXPECT().ValidateAssets(gomock.Any(), assetList, scanID, gomock.Any()).Return(validAssetList, []error{})
 	mockProducer.EXPECT().Produce(gomock.Any(), gomock.Any()).Return(nil).Times(numberOFAssets)
 	mockStatFn.EXPECT().Count("totalassets", float64(numberOFAssets), fmt.Sprintf("site:%s", siteID)).Times(1)
 	mockStatFn.EXPECT().Count("totalassetsproduced", float64(numberOFAssets), fmt.Sprintf("site:%s", siteID)).Times(1)
@@ -112,7 +112,7 @@ func TestNexposeAssetProducerHandlerError(t *testing.T) {
 	validAssetList := []domain.AssetEvent{assetEvent}
 
 	mockAssetFetcher.EXPECT().FetchAssets(gomock.Any(), "12345").Return(assetList, nil)
-	mockAssetValidator.EXPECT().ValidateAssets(gomock.Any(), assetList, scanID).Return(validAssetList, []error{})
+	mockAssetValidator.EXPECT().ValidateAssets(gomock.Any(), assetList, scanID, gomock.Any()).Return(validAssetList, []error{})
 	mockProducer.EXPECT().Produce(gomock.Any(), gomock.Any()).Return(errors.New("i am error"))
 	mockLogger.EXPECT().Error(gomock.Any())
 
@@ -186,7 +186,7 @@ func TestNexposeAssetProducerHandlerMultipleErrors(t *testing.T) {
 	errorList := []error{&domain.ScanIDForLastScanNotInAssetHistory{}, &domain.InvalidScanTime{}, &domain.MissingRequiredInformation{}, errors.New("unknown")}
 
 	mockAssetFetcher.EXPECT().FetchAssets(gomock.Any(), "12345").Return(assetList, nil)
-	mockAssetValidator.EXPECT().ValidateAssets(gomock.Any(), assetList, scanID).Return(validAssetList, errorList)
+	mockAssetValidator.EXPECT().ValidateAssets(gomock.Any(), assetList, scanID, gomock.Any()).Return(validAssetList, errorList)
 
 	handler := NexposeScannedAssetProducer{
 		Producer:       mockProducer,


### PR DESCRIPTION
This is a proposed solution to prevent asset producer from skipping over agent scanned assets. Essentially, since agent scanned assets' histories appear to not have scanIDs, we need another way to check if the scan was recent. This PR proposes that we validate agent scanned assets by checking whether or not their scan was conducted in the past 24 hours. 

 See the results of the PSD-762 investigation here: https://asecurityteam.atlassian.net/browse/PSD-762

> TL;DR: Agent scanned assets lack scanIDs most of the time, so asset-producer skips them for not being a part of the current scanID its processing. We likely need to make an exception to the validation process for agent-scanned assets (site 103) to pass validation.

> If you look at an agent scanned asset's event history, you will see that almost all "SCAN" events in that asset's history are lacking a scanID. You can see this for yourself by querying nexpose for an asset in site 103 in nexpose prod, and reading its event history.

> You can also see this through logs. The failure point in asset-producer is in the function "getScanTime" where it iterates through an asset's event history looking for scanIDs that match the scanID asset-producer is currently processing. But no match is found, and we end up with a ScanIDForLastScanNotInAssetHistory error. This error, which can be seen in the logs for asset-producer dev (where I added this logging), only occurs when an asset either has no scans or lacks a matching scanID to the one being processed.

> Since we can confirm through querying the asset via Nexpose's api that agent scanned assets DO have "SCAN" events, that they almost always lack scanIDs in these events, and that the code path these assets follow indicate either a complete lack of scan events or simply a lack of matching scanIDs, we can conclude asset-producer is skipping agent scanned assets due to the assets' event histories lacking scanIDs.