### PR TITLE
let recent agent scans through asset producer

### DIFF
--- a/pkg/assetvalidator/validateAssets.go
+++ b/pkg/assetvalidator/validateAssets.go
@@ -39,7 +39,8 @@ func (v *NexposeAssetValidator) ValidateAssets(ctx context.Context, assets []dom
 func (v *NexposeAssetValidator) getScanTime(asset domain.Asset, scanID string) (time.Time, error) {
 	for _, evt := range asset.History {
 		scanTime, err := time.Parse(time.RFC3339, evt.Date)
-		if evt.Type == "SCAN" {
+		switch evt.Type {
+		case "SCAN":
 			if strconv.FormatInt(evt.ScanID, 10) == scanID {
 				if err != nil {
 					return time.Time{}, &domain.InvalidScanTime{ScanID: scanID, ScanTime: scanTime, AssetID: asset.ID, AssetIP: asset.IP, AssetHostname: asset.HostName, Inner: err}
@@ -49,9 +50,10 @@ func (v *NexposeAssetValidator) getScanTime(asset domain.Asset, scanID string) (
 				}
 				return scanTime, nil
 			}
-		}
-		if evt.Type == "AGENT-IMPORT" && time.Since(scanTime).Hours() < 24 {
-			return scanTime, nil
+		case "AGENT-IMPORT":
+			if time.Since(scanTime).Hours() < 24 {
+				return scanTime, nil
+			}
 		}
 	}
 	return time.Time{}, &domain.ScanIDForLastScanNotInAssetHistory{ScanID: scanID, AssetID: asset.ID, AssetIP: asset.IP, AssetHostname: asset.HostName}

--- a/pkg/assetvalidator/validateAssets_test.go
+++ b/pkg/assetvalidator/validateAssets_test.go
@@ -10,6 +10,9 @@ import (
 )
 
 func TestAssetValidation(t *testing.T) {
+
+	nowish, _ := time.Parse(time.RFC3339, time.Now().Format(time.RFC3339))
+
 	tests := []struct {
 		name                         string
 		assetList                    []domain.Asset
@@ -147,6 +150,71 @@ func TestAssetValidation(t *testing.T) {
 					ScanID:        "6",
 					AssetIP:       "127.0.0.1",
 					AssetHostname: "ec2-something-my-test-instance.com",
+				},
+			},
+		},
+		{
+			"agent scan success case",
+			[]domain.Asset{
+				{
+					ID:       1,
+					IP:       "127.0.0.1",
+					HostName: "ec2-something-my-test-instance.com",
+					History:  domain.AssetHistoryEvents{domain.AssetHistory{Type: "SCAN", ScanID: 6, Date: "2019-04-22T15:02:44.000Z"}},
+				},
+				{
+					ID:       2,
+					IP:       "127.0.0.2",
+					HostName: "ec2-something-my-test-instance2.com",
+					History:  domain.AssetHistoryEvents{domain.AssetHistory{Type: "AGENT-IMPORT", ScanID: 6, Date: nowish.Format(time.RFC3339)}},
+				},
+			},
+			[]domain.AssetEvent{
+				{
+					ID:       1,
+					IP:       "127.0.0.1",
+					Hostname: "ec2-something-my-test-instance.com",
+					ScanTime: time.Date(2019, time.April, 22, 15, 2, 44, 0, time.UTC),
+				},
+				{
+					ID:       2,
+					IP:       "127.0.0.2",
+					Hostname: "ec2-something-my-test-instance2.com",
+					ScanTime: nowish,
+				},
+			},
+			[]error{},
+		},
+		{
+			"agent scan failure case",
+			[]domain.Asset{
+				{
+					ID:       1,
+					IP:       "127.0.0.1",
+					HostName: "ec2-something-my-test-instance.com",
+					History:  domain.AssetHistoryEvents{domain.AssetHistory{Type: "SCAN", ScanID: 6, Date: "2019-04-22T15:02:44.000Z"}},
+				},
+				{
+					ID:       2,
+					IP:       "127.0.0.2",
+					HostName: "ec2-something-my-test-instance2.com",
+					History:  domain.AssetHistoryEvents{domain.AssetHistory{Type: "AGENT-IMPORT", ScanID: 6, Date: "2019-04-22T15:02:44.000Z"}},
+				},
+			},
+			[]domain.AssetEvent{
+				{
+					ID:       1,
+					IP:       "127.0.0.1",
+					Hostname: "ec2-something-my-test-instance.com",
+					ScanTime: time.Date(2019, time.April, 22, 15, 2, 44, 0, time.UTC),
+				},
+			},
+			[]error{
+				&domain.ScanIDForLastScanNotInAssetHistory{
+					AssetID:       2,
+					ScanID:        "6",
+					AssetIP:       "127.0.0.2",
+					AssetHostname: "ec2-something-my-test-instance2.com",
 				},
 			},
 		},


### PR DESCRIPTION
Fixes asset producer to accept agent scan results given they occurred in the last 24 hours.